### PR TITLE
Update ApiClient with parseErrorMessage and baseUrl formatter

### DIFF
--- a/app/src/main/java/com/grupo1/deremate/di/NetworkModule.kt
+++ b/app/src/main/java/com/grupo1/deremate/di/NetworkModule.kt
@@ -14,6 +14,6 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideApiClient(): ApiClient {
-        return ApiClient().setBaseUrl("http://10.0.2.2:8080")
+        return ApiClient().setBaseUrl("http://10.0.2.2:4002")
     }
 }


### PR DESCRIPTION
🔧 Se agregó el método `parseErrorMessage` para mejorar la lectura de errores del backend.
🔧 Se incorporó `ensureEndsWithSlash()` para evitar fallas en la base URL.

Esto permite respuestas más limpias y visibles para el usuario final en el login u otras llamadas protegidas.
